### PR TITLE
Add __main__.py to make the package executable

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,8 +17,8 @@ jobs:
         run: |
           mkdir work
           cd work
-          python -m msgflow.main init
-          echo Hello | python -m msgflow.main run --config_file=config.yml
+          python -m msgflow init
+          echo Hello | python -m msgflow run --config_file=config.yml
           cd ..
       - name: Check code style
         run: black --check msgflow tests

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ $ cd work/
 msgFlow provides `init` command to generate the configuratio file and App script for you.
 
 ```sh
-$ python -m msgflow.main init
+$ python -m msgflow init
 $ ls
 app.py  config.yml
 ```
@@ -45,7 +45,7 @@ Let us run the msgFlow with the Config setting.
 You can utilize the `run` command with `--config_file` option which specify the default config file.
 
 ```sh
-$ python -m msgflow.main run --config_file config.yml
+$ python -m msgflow run --config_file config.yml
 INFO:/work/msgflow/main.py:{"level": "info", "message": {"service": "CliService", "post_service": "CliService"}, "time": "2020-12-26 11:10:43.886375"}
 ```
 

--- a/msgflow/__main__.py
+++ b/msgflow/__main__.py
@@ -1,0 +1,5 @@
+if __name__ == "__main__":
+    import fire
+    from .main import Main
+
+    fire.Fire(Main)


### PR DESCRIPTION
This PR enables msgflow to be executable. Instead of running msgflow as `python -m msgflow.main`, this PR allows users just to call it as `python -m msgflow` .